### PR TITLE
Pequeña corrección en AddNewsButton y cómo recoge newsCreate

### DIFF
--- a/src/layout/addNewsButton/AddNewsButton.jsx
+++ b/src/layout/addNewsButton/AddNewsButton.jsx
@@ -7,12 +7,14 @@ function AddNewsButton() {
   //   const [form, setForm] = useState(false);
   const newsCreate = useRef(null);
   const closeNewsMenu = (e) => {
-    if (newsCreate.current.contains(e.target)) {
+    if (newsCreate.current && newsCreate.current.contains(e.target)) {
       return;
-    } else setShow(!show);
+    } else {
+      setShow(!show);
+    }
   };
   useEffect(() => {
-    if (newsCreate) {
+    if (newsCreate.current) {
       document.addEventListener('mousedown', closeNewsMenu);
     } else {
       document.removeEventListener('mousedown', closeNewsMenu);
@@ -22,7 +24,6 @@ function AddNewsButton() {
       document.removeEventListener('mousedown', closeNewsMenu);
     };
   }, [show]);
-
   const handleAddNewsButton = () => {
     setShow(!show);
     // setForm(!form);


### PR DESCRIPTION
Corrección para el error que se produce cuando intentas acceder a newsCreate.current en la función closeNewsMenu, pero newsCreate.current es null.